### PR TITLE
Add missing keyId hash

### DIFF
--- a/backend/src/activitypub/deliver.ts
+++ b/backend/src/activitypub/deliver.ts
@@ -33,7 +33,12 @@ export async function deliverToActor(
 	})
 	const digest = await generateDigestHeader(body)
 	req.headers.set('Digest', digest)
-	await signRequest(req, signingKey, new URL(from.id))
+
+	const keyId = new URL(from.id)
+	if (keyId.hostname == domain) {
+		keyId.hash = '#main-key'
+	}
+	await signRequest(req, signingKey, keyId)
 
 	const res = await fetch(req)
 	if (!res.ok) {


### PR DESCRIPTION
Key ID hash (`#main-key`) is appended below but request is signed without the hash.

https://github.com/mzyy94/wildebeest/blob/a52ae709f319089753822a1561e0c05bda7190a4/backend/src/activitypub/actors/index.ts#L287-L291